### PR TITLE
Adds Strangelove Project Management Workflow

### DIFF
--- a/.github/workflows/strangelove-project-management.yaml
+++ b/.github/workflows/strangelove-project-management.yaml
@@ -1,0 +1,25 @@
+name: Strangelove Project Management
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+      - closed
+
+jobs:
+  issue_opened_or_reopened:
+    name: issue_opened_or_reopened
+    runs-on: ubuntu-latest
+    if: |
+      startsWith(github.repository,'strangelove-ventures/') && 
+      github.event_name == 'issues' && (github.event.action == 'opened' || github.event.action == 'reopened')
+    steps:
+      - name: Add Issue to "Motherboard" Project Board
+        uses: leonsteinhaeuser/project-beta-automations@v1.2.1
+        with:
+          gh_app_secret_key: ${{ secrets.MB_SECRET_KEY }}
+          gh_app_ID: ${{ secrets.MB_APP_ID }}
+          gh_app_installation_ID: ${{ secrets.MB_INSTALLATION_ID }}
+          organization: strangelove-ventures
+          project_id: 4
+          resource_node_id: ${{ github.event.issue.node_id }}


### PR DESCRIPTION
This PR is for Strangelove project management.

The workflow file created will automatically add issues to an internal Github project board.

The goal of this is to help Strangelove prioritize tasks and stay on top of the plethora of projects we are involved in.

If this repo is forked, this action should automatically be skipped.

Please don't let this effect who or how issues are created or written